### PR TITLE
Support various shortened versions of commands

### DIFF
--- a/src/Text/Pandoc/Readers/LaTeX.hs
+++ b/src/Text/Pandoc/Readers/LaTeX.hs
@@ -1264,6 +1264,8 @@ inlineCommands = M.fromList $
   , ("it", extractSpaces emph <$> inlines)
   , ("sl", extractSpaces emph <$> inlines)
   , ("bf", extractSpaces strong <$> inlines)
+  , ("sf", extractSpaces (spanWith ("",["sans-serif"],[])) <$> tok)
+  , ("sc", extractSpaces smallcaps <$> tok)
   , ("rm", inlines)
   , ("itshape", extractSpaces emph <$> inlines)
   , ("slshape", extractSpaces emph <$> inlines)


### PR DESCRIPTION
I needed \sf, but there are a bunch here that seem worth
supporting too:
http://www.emerson.emory.edu/services/latex/latex_168.html#SEC168